### PR TITLE
packaging: build python zipapp (pyz) executable distribution

### DIFF
--- a/.github/workflows/build-pyz.yml
+++ b/.github/workflows/build-pyz.yml
@@ -1,0 +1,14 @@
+name: Build PYZ distribution
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    uses: internet-equity/fate-pyz/.github/workflows/build-pyz.yml@0.1.1
+    with:
+      app-main: netrics
+      app-alts: netrics.+
+      app-solo: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "netrics", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-fate-scheduler = "0.1.0-rc.9"
+fate-scheduler = "0.1.0-rc.10"
 netifaces = "^0.11.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
…via github workflow

Supports x86_64 and arm64 across all otherwise-supported versions of Python.